### PR TITLE
feat: added path string navigation (DO NOT MERGE)

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,12 @@ const bar = foo.prop('bar')
 const bar = O.optic<Data>().path(['foo', 'bar'])
 ```
 
+Or
+```typescript
+const bar = O.optic<Data>().prop('foo.bar')
+```
+
+
 Use `get()` to read a value through the lens:
 
 ```typescript

--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
     "doctoc": "^1.4.0",
     "jest": "^26.0.1",
     "prettier": "^2.0.2",
-    "ts-jest": "^26.0.0",
+    "ts-jest": "^26.4.1",
     "ts-node": "^8.8.1",
-    "typescript": "^3.8.3"
+    "typescript": "beta"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,20 +45,6 @@ export type NextComposeParams<
 export type OpticFor<S> = Equivalence<S, Params<DisallowTypeChange<S>>, S>
 export type OpticFor_<S> = Equivalence<S, Params<Id>, S>
 
-export type MatchPath<Obj,Path> =
-//Null check
-  Obj extends null | undefined ? Obj :
-    //Path empty check
-    Path extends (undefined | null | '' ) ? Obj :
-      //Path in Obj keys return it -- we are done
-      Path extends keyof Obj ? Obj[Path] :
-        //Otherwise split string on `.`
-        Path extends `${infer P}.${infer Rest}` ?
-          //if P is in Obj recurse
-          P extends keyof Obj ?  MatchPath<Obj[P], Rest>
-            : never : never;
-
-
 type MatchLensPath<S, K, A, T extends OpticParams> =
     K extends keyof A ? Lens<S, NextParams<T, Prop<A, K>>, A[K]> :
       K extends `${infer P}.${infer Rest}` ?

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,11 +46,11 @@ export type OpticFor<S> = Equivalence<S, Params<DisallowTypeChange<S>>, S>
 export type OpticFor_<S> = Equivalence<S, Params<Id>, S>
 
 type MatchLensPath<S, K, A, T extends OpticParams> =
-    K extends keyof A ? Lens<S, NextParams<T, Prop<A, K>>, A[K]> :
-      K extends `${infer P}.${infer Rest}` ?
-        P extends keyof A ? MatchLensPath<S, Rest, A[P], T> :
-          never :
-            never;
+  K extends keyof A ? Lens<S, NextParams<T, Prop<A, K>>, A[K]> :
+    K extends `${infer P}.${infer Rest}` ?
+      P extends keyof A ? MatchLensPath<S, Rest, A[P], T> :
+        never :
+      never;
 
 export interface Equivalence<S, T extends OpticParams, A> {
   readonly _tag: 'Equivalence'
@@ -74,7 +74,7 @@ export interface Equivalence<S, T extends OpticParams, A> {
   compose<T2 extends OpticParams, A2>(
     optic: Lens<A, T2, A2>
   ): Lens<S, NextComposeParams<T, T2>, A2>
-  prop<K extends string>(key: K): MatchLensPath<S, K, A, T>,
+  prop<K extends string>(key: K): MatchLensPath<S, K, A, T>
   path<
     K1 extends keyof A,
     K2 extends keyof A[K1],

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,27 @@ export type NextComposeParams<
 export type OpticFor<S> = Equivalence<S, Params<DisallowTypeChange<S>>, S>
 export type OpticFor_<S> = Equivalence<S, Params<Id>, S>
 
+export type MatchPath<Obj,Path> =
+//Null check
+  Obj extends null | undefined ? Obj :
+    //Path empty check
+    Path extends (undefined | null | '' ) ? Obj :
+      //Path in Obj keys return it -- we are done
+      Path extends keyof Obj ? Obj[Path] :
+        //Otherwise split string on `.`
+        Path extends `${infer P}.${infer Rest}` ?
+          //if P is in Obj recurse
+          P extends keyof Obj ?  MatchPath<Obj[P], Rest>
+            : never : never;
+
+
+type MatchLensPath<S, K, A, T extends OpticParams> =
+    K extends keyof A ? Lens<S, NextParams<T, Prop<A, K>>, A[K]> :
+      K extends `${infer P}.${infer Rest}` ?
+        P extends keyof A ? MatchLensPath<S, Rest, A[P], T> :
+          never :
+            never;
+
 export interface Equivalence<S, T extends OpticParams, A> {
   readonly _tag: 'Equivalence'
   readonly _removable: T['_R']
@@ -67,7 +88,7 @@ export interface Equivalence<S, T extends OpticParams, A> {
   compose<T2 extends OpticParams, A2>(
     optic: Lens<A, T2, A2>
   ): Lens<S, NextComposeParams<T, T2>, A2>
-  prop<K extends keyof A>(key: K): Lens<S, NextParams<T, Prop<A, K>>, A[K]>
+  prop<K extends string>(key: K): MatchLensPath<S, K, A, T>,
   path<
     K1 extends keyof A,
     K2 extends keyof A[K1],

--- a/src/internals.ts
+++ b/src/internals.ts
@@ -17,12 +17,12 @@ const Right = <T>(value: T): Right<T> => ({
 const either = <E, T, U>(
   mapLeft: (value: E) => U,
   mapRight: (value: T) => U,
-  e: Either<E, T>
+  e: Either<E, T>,
 ): U => (e._tag === 'Left' ? mapLeft(e.value) : mapRight(e.value))
 
 const profunctorFn = {
   dimap: (f: (x: any) => any, g: (x: any) => any, fn: (x: any) => any) => (
-    x: any
+    x: any,
   ) => g(fn(f(x))),
   first: (f: (x: any) => any) => ([x, y]: [any, any]) => [f(x), y],
   right: (f: (x: any) => any) => (e: Either<any, any>): Either<any, any> =>
@@ -54,7 +54,7 @@ const monoidArray = {
 
 const profunctorConst = (monoid: any) => ({
   dimap: (f: (x: any) => any, _g: (x: any) => any, toF: (x: any) => any) => (
-    x: any
+    x: any,
   ) => toF(f(x)),
   first: (toF: (x: any) => any) => ([x, _y]: [any, any]) => toF(x),
   right: (toF: (x: any) => any) => (e: Either<any, any>) =>
@@ -188,12 +188,13 @@ type Profunctor = any
 interface OpticFn {
   _tag: OpticType
   _removable?: true | undefined
+
   (P: Profunctor, optic: OpticFn): any
 }
 
 const withTag = (
   tag: OpticType,
-  optic: (P: Profunctor, optic: OpticFn) => any
+  optic: (P: Profunctor, optic: OpticFn) => any,
 ): OpticFn => {
   const result = optic as OpticFn
   result._tag = tag
@@ -232,17 +233,17 @@ const iso = (there: (x: any) => any, back: (x: any) => any): OpticFn =>
 
 const lens = (view: (x: any) => any, update: (x: any) => any): OpticFn =>
   withTag('Lens', (P: Profunctor, optic: OpticFn): any =>
-    P.dimap((x: any) => [view(x), x], update, P.first(optic))
+    P.dimap((x: any) => [view(x), x], update, P.first(optic)),
   )
 
 const prism = (match: (x: any) => any, build: (x: any) => any): OpticFn =>
   withTag('Prism', (P: any, optic: any): any =>
-    P.dimap(match, (x: any) => either(id, build, x), P.right(optic))
+    P.dimap(match, (x: any) => either(id, build, x), P.right(optic)),
   )
 
 const elems = withTag(
   'Traversal',
-  (P: any, optic: any): OpticFn => P.dimap(id, id, P.wander(optic))
+  (P: any, optic: any): OpticFn => P.dimap(id, id, P.wander(optic)),
 )
 
 const to = (fn: (a: any) => any): OpticFn =>
@@ -273,7 +274,7 @@ export const collect = (optic: any, source: any): any =>
 const prop = (key: string): OpticFn =>
   lens(
     (source: any) => source[key],
-    ([value, source]: [any, any]) => ({ ...source, [key]: value })
+    ([value, source]: [any, any]) => ({ ...source, [key]: value }),
   )
 
 const pick = (keys: string[]): OpticFn =>
@@ -291,7 +292,7 @@ const pick = (keys: string[]): OpticFn =>
         delete result[key]
       }
       return Object.assign(result, value)
-    }
+    },
   )
 
 const when = (pred: (x: any) => boolean): OpticFn =>
@@ -334,15 +335,15 @@ const at = (i: number): OpticFn =>
             result[i] = value
             return result
           }
-        }
+        },
       ),
-      mustMatch
-    )
+      mustMatch,
+    ),
   )
 
 const optional: OpticFn = prism(
   (source: any) => (source === undefined ? Left(undefined) : Right(source)),
-  id
+  id,
 )
 
 const guard = <A, U extends A>(fn: (a: A) => a is U): OpticFn =>
@@ -351,7 +352,7 @@ const guard = <A, U extends A>(fn: (a: A) => a is U): OpticFn =>
 // Like at(0), but the zero'th index must always be defined
 const fst = lens(
   value => value[0],
-  ([value, source]) => [value, source[1]]
+  ([value, source]) => [value, source[1]],
 )
 
 const find = (predicate: (item: any) => boolean): OpticFn =>
@@ -375,11 +376,11 @@ const find = (predicate: (item: any) => boolean): OpticFn =>
           const result = source.slice()
           result[index] = value
           return result
-        }
+        },
       ),
       fst,
-      mustMatch
-    )
+      mustMatch,
+    ),
   )
 
 const filter = (predicate: (item: any) => boolean): OpticFn =>
@@ -401,13 +402,13 @@ const filter = (predicate: (item: any) => boolean): OpticFn =>
         j++
       }
       return result
-    }
+    },
   )
 
 const valueOr = (defaultValue: any): OpticFn =>
   lens(
     (source: any) => (source === undefined ? defaultValue : source),
-    ([value, source]: [any, any]) => value
+    ([value, source]: [any, any]) => value,
   )
 
 const prependTo: OpticFn = lens(
@@ -415,7 +416,7 @@ const prependTo: OpticFn = lens(
   ([value, source]: [any, any[]]) => {
     if (value === undefined) return source
     return [value, ...source]
-  }
+  },
 )
 
 const appendTo: OpticFn = lens(
@@ -423,30 +424,31 @@ const appendTo: OpticFn = lens(
   ([value, source]: [any, any[]]) => {
     if (value === undefined) return source
     return [...source, value]
-  }
+  },
 )
 
 const chars: OpticFn = compose(
   iso(
     s => s.split(''),
-    a => a.join('')
+    a => a.join(''),
   ),
-  elems
+  elems,
 )
 
 const words: OpticFn = compose(
   iso(
     s => s.split(/\b/),
-    a => a.join('')
+    a => a.join(''),
   ),
   elems,
-  when(s => !/\s+/.test(s))
+  when(s => !/\s+/.test(s)),
 )
 
 /////////////////////////////////////////////////////////////////////////////
 
 export class Optic {
-  constructor(public _ref: OpticFn) {}
+  constructor(public _ref: OpticFn) {
+  }
 
   get _tag(): OpticType {
     return this._ref._tag
@@ -465,12 +467,17 @@ export class Optic {
   }
 
   prop(key: string): Optic {
-    return new Optic(compose(this._ref, prop(key)))
+    const parts = key.split('.')
+    if (parts.length === 1) {
+      return new Optic(compose(this._ref, prop(key)))
+    } else {
+      return this.path(parts)
+    }
   }
 
   path(keys: string[]): Optic {
     return new Optic(
-      keys.reduce((ref, key) => compose(ref, prop(key)), this._ref)
+      keys.reduce((ref, key) => compose(ref, prop(key)), this._ref),
     )
   }
 

--- a/src/internals.ts
+++ b/src/internals.ts
@@ -17,12 +17,12 @@ const Right = <T>(value: T): Right<T> => ({
 const either = <E, T, U>(
   mapLeft: (value: E) => U,
   mapRight: (value: T) => U,
-  e: Either<E, T>,
+  e: Either<E, T>
 ): U => (e._tag === 'Left' ? mapLeft(e.value) : mapRight(e.value))
 
 const profunctorFn = {
   dimap: (f: (x: any) => any, g: (x: any) => any, fn: (x: any) => any) => (
-    x: any,
+    x: any
   ) => g(fn(f(x))),
   first: (f: (x: any) => any) => ([x, y]: [any, any]) => [f(x), y],
   right: (f: (x: any) => any) => (e: Either<any, any>): Either<any, any> =>
@@ -54,7 +54,7 @@ const monoidArray = {
 
 const profunctorConst = (monoid: any) => ({
   dimap: (f: (x: any) => any, _g: (x: any) => any, toF: (x: any) => any) => (
-    x: any,
+    x: any
   ) => toF(f(x)),
   first: (toF: (x: any) => any) => ([x, _y]: [any, any]) => toF(x),
   right: (toF: (x: any) => any) => (e: Either<any, any>) =>
@@ -194,7 +194,7 @@ interface OpticFn {
 
 const withTag = (
   tag: OpticType,
-  optic: (P: Profunctor, optic: OpticFn) => any,
+  optic: (P: Profunctor, optic: OpticFn) => any
 ): OpticFn => {
   const result = optic as OpticFn
   result._tag = tag
@@ -233,17 +233,17 @@ const iso = (there: (x: any) => any, back: (x: any) => any): OpticFn =>
 
 const lens = (view: (x: any) => any, update: (x: any) => any): OpticFn =>
   withTag('Lens', (P: Profunctor, optic: OpticFn): any =>
-    P.dimap((x: any) => [view(x), x], update, P.first(optic)),
+    P.dimap((x: any) => [view(x), x], update, P.first(optic))
   )
 
 const prism = (match: (x: any) => any, build: (x: any) => any): OpticFn =>
   withTag('Prism', (P: any, optic: any): any =>
-    P.dimap(match, (x: any) => either(id, build, x), P.right(optic)),
+    P.dimap(match, (x: any) => either(id, build, x), P.right(optic))
   )
 
 const elems = withTag(
   'Traversal',
-  (P: any, optic: any): OpticFn => P.dimap(id, id, P.wander(optic)),
+  (P: any, optic: any): OpticFn => P.dimap(id, id, P.wander(optic))
 )
 
 const to = (fn: (a: any) => any): OpticFn =>
@@ -274,7 +274,7 @@ export const collect = (optic: any, source: any): any =>
 const prop = (key: string): OpticFn =>
   lens(
     (source: any) => source[key],
-    ([value, source]: [any, any]) => ({ ...source, [key]: value }),
+    ([value, source]: [any, any]) => ({ ...source, [key]: value })
   )
 
 const pick = (keys: string[]): OpticFn =>
@@ -292,7 +292,7 @@ const pick = (keys: string[]): OpticFn =>
         delete result[key]
       }
       return Object.assign(result, value)
-    },
+    }
   )
 
 const when = (pred: (x: any) => boolean): OpticFn =>
@@ -335,15 +335,15 @@ const at = (i: number): OpticFn =>
             result[i] = value
             return result
           }
-        },
+        }
       ),
-      mustMatch,
-    ),
+      mustMatch
+    )
   )
 
 const optional: OpticFn = prism(
   (source: any) => (source === undefined ? Left(undefined) : Right(source)),
-  id,
+  id
 )
 
 const guard = <A, U extends A>(fn: (a: A) => a is U): OpticFn =>
@@ -352,7 +352,7 @@ const guard = <A, U extends A>(fn: (a: A) => a is U): OpticFn =>
 // Like at(0), but the zero'th index must always be defined
 const fst = lens(
   value => value[0],
-  ([value, source]) => [value, source[1]],
+  ([value, source]) => [value, source[1]]
 )
 
 const find = (predicate: (item: any) => boolean): OpticFn =>
@@ -376,11 +376,11 @@ const find = (predicate: (item: any) => boolean): OpticFn =>
           const result = source.slice()
           result[index] = value
           return result
-        },
+        }
       ),
       fst,
-      mustMatch,
-    ),
+      mustMatch
+    )
   )
 
 const filter = (predicate: (item: any) => boolean): OpticFn =>
@@ -402,13 +402,13 @@ const filter = (predicate: (item: any) => boolean): OpticFn =>
         j++
       }
       return result
-    },
+    }
   )
 
 const valueOr = (defaultValue: any): OpticFn =>
   lens(
     (source: any) => (source === undefined ? defaultValue : source),
-    ([value, source]: [any, any]) => value,
+    ([value, source]: [any, any]) => value
   )
 
 const prependTo: OpticFn = lens(
@@ -416,7 +416,7 @@ const prependTo: OpticFn = lens(
   ([value, source]: [any, any[]]) => {
     if (value === undefined) return source
     return [value, ...source]
-  },
+  }
 )
 
 const appendTo: OpticFn = lens(
@@ -424,31 +424,30 @@ const appendTo: OpticFn = lens(
   ([value, source]: [any, any[]]) => {
     if (value === undefined) return source
     return [...source, value]
-  },
+  }
 )
 
 const chars: OpticFn = compose(
   iso(
     s => s.split(''),
-    a => a.join(''),
+    a => a.join('')
   ),
-  elems,
+  elems
 )
 
 const words: OpticFn = compose(
   iso(
     s => s.split(/\b/),
-    a => a.join(''),
+    a => a.join('')
   ),
   elems,
-  when(s => !/\s+/.test(s)),
+  when(s => !/\s+/.test(s))
 )
 
 /////////////////////////////////////////////////////////////////////////////
 
 export class Optic {
-  constructor(public _ref: OpticFn) {
-  }
+  constructor(public _ref: OpticFn) {}
 
   get _tag(): OpticType {
     return this._ref._tag
@@ -477,7 +476,7 @@ export class Optic {
 
   path(keys: string[]): Optic {
     return new Optic(
-      keys.reduce((ref, key) => compose(ref, prop(key)), this._ref),
+      keys.reduce((ref, key) => compose(ref, prop(key)), this._ref)
     )
   }
 

--- a/tests/optic.spec.ts
+++ b/tests/optic.spec.ts
@@ -140,6 +140,19 @@ describe('lens/path', () => {
     })
   })
 })
+describe('lens/path/prop', () => {
+  type Source = { foo: { bar: { baz: string } }; xyzzy: number }
+  const source: Source = { foo: { bar: { baz: 'quux' } }, xyzzy: 42 }
+
+  const lens = O.optic_<Source>().prop('foo.bar.baz')
+  type Focus = string
+
+  it('get', () => {
+    const result: Focus = O.get(lens)(source)
+    expect(result).toEqual('quux')
+  })
+
+})
 
 describe('lens/pick', () => {
   type Source = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -456,6 +456,17 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
+"@jest/types@^26.6.0":
+  version "26.6.0"
+  resolved "http://npm.paypal.com/artifactory/api/npm/npm-all/@jest/types/-/types-26.6.0.tgz#2c045f231bfd79d52514cda3fbc93ef46157fa6a"
+  integrity sha1-LARfIxv9edUlFM2j+8k+9GFX+mo=
+  dependencies:
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^3.0.0"
+    "@types/node" "*"
+    "@types/yargs" "^15.0.0"
+    chalk "^4.0.0"
+
 "@sinonjs/commons@^1.7.0":
   version "1.7.2"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.7.2.tgz#505f55c74e0272b43f6c52d81946bed7058fc0e2"
@@ -552,6 +563,21 @@
   dependencies:
     "@types/istanbul-lib-coverage" "*"
     "@types/istanbul-lib-report" "*"
+
+"@types/istanbul-reports@^3.0.0":
+  version "3.0.0"
+  resolved "http://npm.paypal.com/artifactory/api/npm/npm-all/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz#508b13aa344fa4976234e75dddcc34925737d821"
+  integrity sha1-UIsTqjRPpJdiNOdd3cw0klc32CE=
+  dependencies:
+    "@types/istanbul-lib-report" "*"
+
+"@types/jest@26.x":
+  version "26.0.15"
+  resolved "http://npm.paypal.com/artifactory/api/npm/npm-all/@types/jest/-/jest-26.0.15.tgz#12e02c0372ad0548e07b9f4e19132b834cb1effe"
+  integrity sha1-EuAsA3KtBUjge59OGRMrg0yx7/4=
+  dependencies:
+    jest-diff "^26.0.0"
+    pretty-format "^26.0.0"
 
 "@types/jest@^25.1.4":
   version "25.2.2"
@@ -1218,6 +1244,11 @@ diff-sequences@^26.0.0:
   version "26.0.0"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-26.0.0.tgz#0760059a5c287637b842bd7085311db7060e88a6"
   integrity sha512-JC/eHYEC3aSS0vZGjuoc4vHA0yAQTzhQQldXMeMF+JlxLGJlCO38Gma82NV9gk1jGFz8mDzUMeaKXvjRRdJ2dg==
+
+diff-sequences@^26.5.0:
+  version "26.5.0"
+  resolved "http://npm.paypal.com/artifactory/api/npm/npm-all/diff-sequences/-/diff-sequences-26.5.0.tgz#ef766cf09d43ed40406611f11c6d8d9dd8b2fefd"
+  integrity sha1-73Zs8J1D7UBAZhHxHG2Nndiy/v0=
 
 diff@^4.0.1:
   version "4.0.2"
@@ -2064,6 +2095,16 @@ jest-diff@^25.2.1:
     jest-get-type "^25.2.6"
     pretty-format "^25.5.0"
 
+jest-diff@^26.0.0:
+  version "26.6.0"
+  resolved "http://npm.paypal.com/artifactory/api/npm/npm-all/jest-diff/-/jest-diff-26.6.0.tgz#5e5bbbaf93ec5017fae2b3ef12fc895e29988379"
+  integrity sha1-Xlu7r5PsUBf64rPvEvyJXimYg3k=
+  dependencies:
+    chalk "^4.0.0"
+    diff-sequences "^26.5.0"
+    jest-get-type "^26.3.0"
+    pretty-format "^26.6.0"
+
 jest-diff@^26.0.1:
   version "26.0.1"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-26.0.1.tgz#c44ab3cdd5977d466de69c46929e0e57f89aa1de"
@@ -2124,6 +2165,11 @@ jest-get-type@^26.0.0:
   version "26.0.0"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-26.0.0.tgz#381e986a718998dbfafcd5ec05934be538db4039"
   integrity sha512-zRc1OAPnnws1EVfykXOj19zo2EMw5Hi6HLbFCSjpuJiXtOWAYIjNsHVSbpQ8bDX7L5BGYGI8m+HmKdjHYFF0kg==
+
+jest-get-type@^26.3.0:
+  version "26.3.0"
+  resolved "http://npm.paypal.com/artifactory/api/npm/npm-all/jest-get-type/-/jest-get-type-26.3.0.tgz#e97dc3c3f53c2b406ca7afaed4493b1d099199e0"
+  integrity sha1-6X3Dw/U8K0Bsp6+u1Ek7HQmRmeA=
 
 jest-haste-map@^26.0.1:
   version "26.0.1"
@@ -2335,6 +2381,18 @@ jest-util@^26.0.1:
     graceful-fs "^4.2.4"
     is-ci "^2.0.0"
     make-dir "^3.0.0"
+
+jest-util@^26.1.0:
+  version "26.6.0"
+  resolved "http://npm.paypal.com/artifactory/api/npm/npm-all/jest-util/-/jest-util-26.6.0.tgz#a81547f6d38738b505c5a594b37d911335dea60f"
+  integrity sha1-qBVH9tOHOLUFxaWUs32REzXepg8=
+  dependencies:
+    "@jest/types" "^26.6.0"
+    "@types/node" "*"
+    chalk "^4.0.0"
+    graceful-fs "^4.2.4"
+    is-ci "^2.0.0"
+    micromatch "^4.0.2"
 
 jest-validate@^26.0.1:
   version "26.0.1"
@@ -2579,14 +2637,6 @@ merge-stream@^2.0.0:
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
   integrity sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
 
-micromatch@4.x, micromatch@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.2.tgz#4fcb0999bf9fbc2fcbdd212f6d629b9a56c39259"
-  integrity sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==
-  dependencies:
-    braces "^3.0.1"
-    picomatch "^2.0.5"
-
 micromatch@^3.1.4:
   version "3.1.10"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.10.tgz#70859bc95c9840952f359a068a3fc49f9ecfac23"
@@ -2605,6 +2655,14 @@ micromatch@^3.1.4:
     regex-not "^1.0.0"
     snapdragon "^0.8.1"
     to-regex "^3.0.2"
+
+micromatch@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.2.tgz#4fcb0999bf9fbc2fcbdd212f6d629b9a56c39259"
+  integrity sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==
+  dependencies:
+    braces "^3.0.1"
+    picomatch "^2.0.5"
 
 mime-db@1.44.0:
   version "1.44.0"
@@ -2933,6 +2991,16 @@ pretty-format@^25.2.1, pretty-format@^25.5.0:
   integrity sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==
   dependencies:
     "@jest/types" "^25.5.0"
+    ansi-regex "^5.0.0"
+    ansi-styles "^4.0.0"
+    react-is "^16.12.0"
+
+pretty-format@^26.0.0, pretty-format@^26.6.0:
+  version "26.6.0"
+  resolved "http://npm.paypal.com/artifactory/api/npm/npm-all/pretty-format/-/pretty-format-26.6.0.tgz#1e1030e3c70e3ac1c568a5fd15627671ea159391"
+  integrity sha1-HhAw48cOOsHFaKX9FWJ2ceoVk5E=
+  dependencies:
+    "@jest/types" "^26.6.0"
     ansi-regex "^5.0.0"
     ansi-styles "^4.0.0"
     react-is "^16.12.0"
@@ -3623,21 +3691,22 @@ trough@^1.0.0:
   resolved "https://registry.yarnpkg.com/trough/-/trough-1.0.5.tgz#b8b639cefad7d0bb2abd37d433ff8293efa5f406"
   integrity sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==
 
-ts-jest@^26.0.0:
-  version "26.0.0"
-  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-26.0.0.tgz#957b802978249aaf74180b9dcb17b4fd787ad6f3"
-  integrity sha512-eBpWH65mGgzobuw7UZy+uPP9lwu+tPp60o324ASRX4Ijg8UC5dl2zcge4kkmqr2Zeuk9FwIjvCTOPuNMEyGWWw==
+ts-jest@^26.4.1:
+  version "26.4.1"
+  resolved "http://npm.paypal.com/artifactory/api/npm/npm-all/ts-jest/-/ts-jest-26.4.1.tgz#08ec0d3fc2c3a39e4a46eae5610b69fafa6babd0"
+  integrity sha1-COwNP8LDo55KRurlYQtp+vprq9A=
   dependencies:
+    "@types/jest" "26.x"
     bs-logger "0.x"
     buffer-from "1.x"
     fast-json-stable-stringify "2.x"
+    jest-util "^26.1.0"
     json5 "2.x"
     lodash.memoize "4.x"
     make-error "1.x"
-    micromatch "4.x"
     mkdirp "1.x"
     semver "7.x"
-    yargs-parser "18.x"
+    yargs-parser "20.x"
 
 ts-node@^8.8.1:
   version "8.10.1"
@@ -3696,10 +3765,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@^3.8.3:
-  version "3.9.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.2.tgz#64e9c8e9be6ea583c54607677dd4680a1cf35db9"
-  integrity sha512-q2ktq4n/uLuNNShyayit+DTobV2ApPEo/6so68JaD5ojvc/6GClBipedB9zNWYxRSAlZXAe405Rlijzl6qDiSw==
+typescript@beta:
+  version "4.1.0-beta"
+  resolved "http://npm.paypal.com/artifactory/api/npm/npm-all/typescript/-/typescript-4.1.0-beta.tgz#e4d054035d253b7a37bdc077dd71706508573e69"
+  integrity sha1-5NBUA10lO3o3vcB33XFwZQhXPmk=
 
 underscore@~1.8.3:
   version "1.8.3"
@@ -3990,7 +4059,12 @@ y18n@^4.0.0:
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
   integrity sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==
 
-yargs-parser@18.x, yargs-parser@^18.1.1:
+yargs-parser@20.x:
+  version "20.2.3"
+  resolved "http://npm.paypal.com/artifactory/api/npm/npm-all/yargs-parser/-/yargs-parser-20.2.3.tgz#92419ba867b858c868acf8bae9bf74af0dd0ce26"
+  integrity sha1-kkGbqGe4WMhorPi66b90rw3QziY=
+
+yargs-parser@^18.1.1:
   version "18.1.3"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.1.3.tgz#be68c4975c6b2abf469236b0c870362fab09a7b0"
   integrity sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==


### PR DESCRIPTION
Was looking at new typescript features and thought this might
be a fun little addition.   I haven't used this library much so, but
am very interested.

This PR allows for `Optic.path` to use a typesafe path with dot 
delineation.   Very similar to lodash.get.   If interested I can put a 
bit effort into it, if not well no problem.

Any feedback is welcome.
