### PR TITLE
Add .nth() lens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.0.0 (unreleased)
+
+- **New features**
+  - Add `.nth()`
+
 ## 1.2.0
 
 - **New features**

--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ yarn add optics-ts
 
 ## Requirements
 
-`optics-ts` requires the [`strictNullChecks` compiler
-option](https://www.typescriptlang.org/tsconfig#strictNullChecks).
+TypeScript >= 4.1 and the [`strictNullChecks` compiler
+option](https://www.typescriptlang.org/tsconfig#strictNullChecks) are required.
 
 I strongly recommend enabling all strict options in your project's
 `tsconfig.json`:
@@ -661,6 +661,15 @@ is equal to
 ```typescript
 foo.prop('a').prop('b').prop('c')
 ```
+
+### `nth<N extends number>(n: N): Lens<S, _, Nth<A, N>>`
+
+Only works on tuples whose length is a least `N + 1`.
+
+Create a lens that focuses on the index `N` of `A`. This is a lens because the
+length of `A` is checked on type level, so index `N` is always defined.
+
+See `at()` below for a similar prism that works on arrays of arbitrary length.
 
 #### `pick<K extends keyof A>(keys: K[]): Lens<S, _, Pick<A, K>>`
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ TypeScript:
   - [Lenses](#lenses)
     - [`prop<K extends keyof A>(key: K): Lens<S, _, A[K]>`](#propk-extends-keyof-akey-k-lenss-_-ak)
     - [`path<K1, K2, ...>(keys: [K1, K2, ...]): Lens<S, _, A[K1][K2]...>`](#pathk1-k2-keys-k1-k2--lenss-_-ak1k2)
+  - [`nth<N extends number>(n: N): Lens<S, _, Nth<A, N>>`](#nthn-extends-numbern-n-lenss-_-ntha-n)
     - [`pick<K extends keyof A>(keys: K[]): Lens<S, _, Pick<A, K>>`](#pickk-extends-keyof-akeys-k-lenss-_-picka-k)
     - [`valueOr<B>(defaultValue: B): Lens<S, _, Exclude<A, undefined> | B>`](#valueorbdefaultvalue-b-lenss-_-excludea-undefined--b)
   - [Prisms](#prisms)

--- a/package.json
+++ b/package.json
@@ -36,6 +36,6 @@
     "prettier": "^2.1.2",
     "ts-jest": "^26.4.3",
     "ts-node": "^9.0.0",
-    "typescript": "^4.0.5"
+    "typescript": "^4.1.0-beta"
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,6 +36,6 @@
     "prettier": "^2.1.2",
     "ts-jest": "^26.4.3",
     "ts-node": "^9.0.0",
-    "typescript": "^4.1.0-beta"
+    "typescript": "^4.1.2"
   }
 }

--- a/scripts/generate-index.ts
+++ b/scripts/generate-index.ts
@@ -8,6 +8,7 @@ import {
   ElemType,
   Eq,
   IfElse,
+  Nth,
   RequireString,
   Simplify
 } from './utils'
@@ -28,6 +29,7 @@ import {
   Plant,
   Prop,
   Optional,
+  SetNth,
   Union,
 } from './hkt'
 
@@ -140,6 +142,7 @@ const lens = (composition: Composition) => `\
     'Prop<A, K1>',
     'A[K1]'
   )}
+  nth<N extends number>(n: N): ${composition.optic('SetNth<A, N>', 'Nth<A, N>')}
   pick<K extends keyof A>(
     keys: K[]
   ): ${composition.optic('Plant<A, K>', 'Pick<A, K>')}

--- a/src/hkt.ts
+++ b/src/hkt.ts
@@ -1,4 +1,4 @@
-import { ElemType, Eq } from './utils'
+import { ElemType, Eq, AnyTuple, Prec } from './utils'
 
 export interface HKT {
   0: unknown
@@ -78,6 +78,18 @@ export interface Path5<
     Path4<S, K1, K2, K3, K4>,
     Omit<S[K1][K2][K3][K4], K5> & { [KK in K5]: this[1] }
   >
+}
+
+type SetNthRec<N extends number, B, S> = N extends 0
+  ? S extends [any, ...infer U]
+    ? [B, ...U]
+    : never
+  : S extends [infer U, ...infer V]
+  ? [U, ...SetNthRec<Prec<N>, B, V>]
+  : never
+
+export interface SetNth<S, N extends number> extends HKT {
+  0: SetNthRec<N, this[1], S>
 }
 
 export interface Plant<S, K extends keyof S> extends HKT {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 // This file is generated, do not edit! See ../scripts/generate-index.ts
 
 import * as I from './internals'
-import { ElemType, Eq, IfElse, RequireString, Simplify } from './utils'
+import { ElemType, Eq, IfElse, Nth, RequireString, Simplify } from './utils'
 import {
   Adapt,
   Apply,
@@ -19,6 +19,7 @@ import {
   Plant,
   Prop,
   Optional,
+  SetNth,
   Union,
 } from './hkt'
 
@@ -94,6 +95,7 @@ export interface Equivalence<S, T extends OpticParams, A> {
   path<K1 extends keyof A>(
     path: [K1]
   ): Lens<S, NextParams<T, Prop<A, K1>>, A[K1]>
+  nth<N extends number>(n: N): Lens<S, NextParams<T, SetNth<A, N>>, Nth<A, N>>
   pick<K extends keyof A>(
     keys: K[]
   ): Lens<S, NextParams<T, Plant<A, K>>, Pick<A, K>>
@@ -221,6 +223,7 @@ export interface Iso<S, T extends OpticParams, A> {
   path<K1 extends keyof A>(
     path: [K1]
   ): Lens<S, NextParams<T, Prop<A, K1>>, A[K1]>
+  nth<N extends number>(n: N): Lens<S, NextParams<T, SetNth<A, N>>, Nth<A, N>>
   pick<K extends keyof A>(
     keys: K[]
   ): Lens<S, NextParams<T, Plant<A, K>>, Pick<A, K>>
@@ -348,6 +351,7 @@ export interface Lens<S, T extends OpticParams, A> {
   path<K1 extends keyof A>(
     path: [K1]
   ): Lens<S, NextParams<T, Prop<A, K1>>, A[K1]>
+  nth<N extends number>(n: N): Lens<S, NextParams<T, SetNth<A, N>>, Nth<A, N>>
   pick<K extends keyof A>(
     keys: K[]
   ): Lens<S, NextParams<T, Plant<A, K>>, Pick<A, K>>
@@ -479,6 +483,7 @@ export interface Prism<S, T extends OpticParams, A> {
   path<K1 extends keyof A>(
     path: [K1]
   ): Prism<S, NextParams<T, Prop<A, K1>>, A[K1]>
+  nth<N extends number>(n: N): Prism<S, NextParams<T, SetNth<A, N>>, Nth<A, N>>
   pick<K extends keyof A>(
     keys: K[]
   ): Prism<S, NextParams<T, Plant<A, K>>, Pick<A, K>>
@@ -610,6 +615,9 @@ export interface Traversal<S, T extends OpticParams, A> {
   path<K1 extends keyof A>(
     path: [K1]
   ): Traversal<S, NextParams<T, Prop<A, K1>>, A[K1]>
+  nth<N extends number>(
+    n: N
+  ): Traversal<S, NextParams<T, SetNth<A, N>>, Nth<A, N>>
   pick<K extends keyof A>(
     keys: K[]
   ): Traversal<S, NextParams<T, Plant<A, K>>, Pick<A, K>>
@@ -729,6 +737,7 @@ export interface Getter<S, A> {
     path: [K1, K2]
   ): Getter<S, A[K1][K2]>
   path<K1 extends keyof A>(path: [K1]): Getter<S, A[K1]>
+  nth<N extends number>(n: N): Getter<S, Nth<A, N>>
   pick<K extends keyof A>(keys: K[]): Getter<S, Pick<A, K>>
   filter(predicate: (item: ElemType<A>) => boolean): Getter<S, A>
   valueOr<B>(defaultValue: B): Getter<S, Exclude<A, undefined> | B>
@@ -813,6 +822,7 @@ export interface AffineFold<S, A> {
     path: [K1, K2]
   ): AffineFold<S, A[K1][K2]>
   path<K1 extends keyof A>(path: [K1]): AffineFold<S, A[K1]>
+  nth<N extends number>(n: N): AffineFold<S, Nth<A, N>>
   pick<K extends keyof A>(keys: K[]): AffineFold<S, Pick<A, K>>
   filter(predicate: (item: ElemType<A>) => boolean): AffineFold<S, A>
   valueOr<B>(defaultValue: B): AffineFold<S, Exclude<A, undefined> | B>
@@ -897,6 +907,7 @@ export interface Fold<S, A> {
     path: [K1, K2]
   ): Fold<S, A[K1][K2]>
   path<K1 extends keyof A>(path: [K1]): Fold<S, A[K1]>
+  nth<N extends number>(n: N): Fold<S, Nth<A, N>>
   pick<K extends keyof A>(keys: K[]): Fold<S, Pick<A, K>>
   filter(predicate: (item: ElemType<A>) => boolean): Fold<S, A>
   valueOr<B>(defaultValue: B): Fold<S, Exclude<A, undefined> | B>

--- a/src/internals.ts
+++ b/src/internals.ts
@@ -294,6 +294,17 @@ const pick = (keys: string[]): OpticFn =>
     }
   )
 
+const nth = (n: number): OpticFn => lens(
+  value => value[n],
+  ([value, source]) => {
+    const result = source.slice()
+    result[n] = value
+    return result
+  }
+)
+
+const fst = nth(0)
+
 const when = (pred: (x: any) => boolean): OpticFn =>
   prism((x: any) => (pred(x) ? Right(x) : Left(x)), id)
 
@@ -347,12 +358,6 @@ const optional: OpticFn = prism(
 
 const guard = <A, U extends A>(fn: (a: A) => a is U): OpticFn =>
   prism((source: A) => (fn(source) ? Right(source) : Left(source)), id)
-
-// Like at(0), but the zero'th index must always be defined
-const fst = lens(
-  value => value[0],
-  ([value, source]) => [value, source[1]]
-)
 
 const find = (predicate: (item: any) => boolean): OpticFn =>
   removable(
@@ -476,6 +481,10 @@ export class Optic {
 
   pick(keys: string[]): Optic {
     return new Optic(compose(this._ref, pick(keys)))
+  }
+
+  nth(n: number): Optic {
+    return new Optic(compose(this._ref, nth(n)))
   }
 
   filter(predicate: (item: any) => boolean): Optic {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -44,3 +44,29 @@ export type RequireString<A, B> = IfElse<
 interface ExpectedStringButGot<_T> {
   readonly _: unique symbol
 }
+
+export type Prec<N> = N extends 6
+  ? 5
+  : N extends 5
+  ? 4
+  : N extends 4
+  ? 3
+  : N extends 3
+  ? 2
+  : N extends 2
+  ? 1
+  : N extends 1
+  ? 0
+  : never
+
+export type AnyTuple<N extends number, Acc extends any[] = []> = N extends 0
+  ? Acc
+  : AnyTuple<Prec<N>, [...Acc, any]>
+
+export type Nth<A, N extends number> = A extends [
+  ...AnyTuple<N>,
+  infer U,
+  ...any[]
+]
+  ? U
+  : never

--- a/tests/optic.spec.ts
+++ b/tests/optic.spec.ts
@@ -141,6 +141,40 @@ describe('lens/path', () => {
   })
 })
 
+describe('lens/nth', () => {
+  type Source = [number, string, boolean]
+  const source: Source = [42, 'foo', true]
+
+  const lens = O.optic_<Source>().nth(1)
+  type Focus = string
+
+  it('get', () => {
+    const result: Focus = O.get(lens)(source)
+    expect(result).toEqual('foo')
+  })
+
+  it('set - monomorphic', () => {
+    const result: Source = O.set(lens)('UPDATED')(source)
+    expect(result).toEqual(
+      [42, 'UPDATED', true]
+    )
+  })
+  it('modify - monomorphic', () => {
+    const result: Source = O.modify(lens)(x => `${x} UPDATED`)(source)
+    expect(result).toEqual([42, 'foo UPDATED', true])
+  })
+
+  type Target = [number, number, boolean]
+  it('set - polymorphic', () => {
+    const result: Target = O.set(lens)(99)(source)
+    expect(result).toEqual([42, 99, true])
+  })
+  it('modify - polymorphic', () => {
+    const result: Target = O.modify(lens)(x => x.length)(source)
+    expect(result).toEqual([42, 3, true])
+  })
+})
+
 describe('lens/pick', () => {
   type Source = {
     foo: string

--- a/yarn.lock
+++ b/yarn.lock
@@ -3759,10 +3759,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@^4.0.5:
-  version "4.0.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.5.tgz#ae9dddfd1069f1cb5beb3ef3b2170dd7c1332389"
-  integrity sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==
+typescript@^4.1.0-beta:
+  version "4.1.0-beta"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.0-beta.tgz#e4d054035d253b7a37bdc077dd71706508573e69"
+  integrity sha512-b/LAttdVl3G6FEmnMkDsK0xvfvaftXpSKrjXn+OVCRqrwz5WD/6QJOiN+dTorqDY+hkaH+r2gP5wI1jBDmdQ7A==
 
 underscore@~1.8.3:
   version "1.8.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3759,10 +3759,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@^4.1.0-beta:
-  version "4.1.0-beta"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.0-beta.tgz#e4d054035d253b7a37bdc077dd71706508573e69"
-  integrity sha512-b/LAttdVl3G6FEmnMkDsK0xvfvaftXpSKrjXn+OVCRqrwz5WD/6QJOiN+dTorqDY+hkaH+r2gP5wI1jBDmdQ7A==
+typescript@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.2.tgz#6369ef22516fe5e10304aae5a5c4862db55380e9"
+  integrity sha512-thGloWsGH3SOxv1SoY7QojKi0tc+8FnOmiarEGMbd/lar7QOEd3hvlx3Fp5y6FlDUGl9L+pd4n2e+oToGMmhRQ==
 
 underscore@~1.8.3:
   version "1.8.3"


### PR DESCRIPTION
It's like `.at()` but a lens instead of a prism. Works for tuples of length 7 and below,

Requires TypeScript >= 4.1, merge only when it's released.