### PR TITLE
fix(tests): add failing test

### DIFF
--- a/tests/optic.spec.ts
+++ b/tests/optic.spec.ts
@@ -594,6 +594,13 @@ describe('lens/filter', () => {
     .prop('bar')
   type Focus = string[]
 
+  it('remove after filter', () => {
+    const filtered = O.optic<Source[]>().filter(pred => pred.bar === 'quux')
+    const filteredAtIndex0 = filtered.at(0)
+    const result = O.remove(filteredAtIndex0)(source)
+    expect(result).toEqual([{ bar: 'baz' }, { bar: 'xyzzy' }])
+  })
+
   it('collect', () => {
     const result: Focus = O.collect(traversal)(source)
     expect(result).toEqual(['baz', 'xyzzy'])


### PR DESCRIPTION
Hello,

Should this be possible?

I expected this test to result in a list with:
```typescript
[{ bar: 'baz' }, { bar: 'xyzzy' }]
```

But it results in a list with:
```typescript
[{ bar: 'baz' }, undefined, { bar: 'xyzzy' }]
```
BUT, the type of the list is: `Source[]`, which doesnt match the type of the list (which should contain `undefined`).

So either the type of the list should be `(Source | undefined)[]`, or the list contents should be what I expected above.

What do you think about this?