### PR TITLE
Fix typo in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ const optic = O.optic_<Book>()
 
 // This is the input data
 const input: Book = {
-  title: "The Hitchhiker's Guide to the Galaxy"
+  title: "The Hitchhiker's Guide to the Galaxy",
   isbn: "978-0345391803",
   author: {
     name: "Douglas Adams"


### PR DESCRIPTION
Please accept this humble syntax fix, I noticed the odd syntax highlighting of `isbn` on the readme

![image](https://user-images.githubusercontent.com/1596818/151702842-e038c289-6e3e-4dd6-bd95-0b48ad1cd291.png)

which is fixed by this commit

![image](https://user-images.githubusercontent.com/1596818/151702850-3d080433-8abe-4317-beb8-f5f97919572a.png)

Love your work! Happy hacking