### PR TITLE
expose general .lens(a => b, a => b => a)

### DIFF
--- a/scripts/generate-index.ts
+++ b/scripts/generate-index.ts
@@ -113,6 +113,10 @@ const iso = (composition: Composition) => `\
 `
 
 const lens = (composition: Composition) => `\
+  lens<U>(
+    view: (a: A) => U,
+    update: (a: A, v: U) => A
+  ): ${composition.optic('Adapt<A, U>', 'U')}
   prop<K extends keyof A>(key: K): ${composition.optic('Prop<A, K>', 'A[K]')}
   path<K extends keyof any>(path: K): ${composition.optic(
     'SetDottedPath<A, K>',

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,6 +79,10 @@ export interface Equivalence<S, T extends OpticParams, A> {
   compose<T2 extends OpticParams, A2>(
     optic: Lens<A, T2, A2>
   ): Lens<S, NextComposeParams<T, T2>, A2>
+  lens<U>(
+    view: (a: A) => U,
+    update: (a: A, v: U) => A
+  ): Lens<S, NextParams<T, Adapt<A, U>>, U>
   prop<K extends keyof A>(key: K): Lens<S, NextParams<T, Prop<A, K>>, A[K]>
   path<K extends keyof any>(
     path: K
@@ -203,6 +207,10 @@ export interface Iso<S, T extends OpticParams, A> {
   compose<T2 extends OpticParams, A2>(
     optic: Lens<A, T2, A2>
   ): Lens<S, NextComposeParams<T, T2>, A2>
+  lens<U>(
+    view: (a: A) => U,
+    update: (a: A, v: U) => A
+  ): Lens<S, NextParams<T, Adapt<A, U>>, U>
   prop<K extends keyof A>(key: K): Lens<S, NextParams<T, Prop<A, K>>, A[K]>
   path<K extends keyof any>(
     path: K
@@ -327,6 +335,10 @@ export interface Lens<S, T extends OpticParams, A> {
   compose<T2 extends OpticParams, A2>(
     optic: Lens<A, T2, A2>
   ): Lens<S, NextComposeParams<T, T2>, A2>
+  lens<U>(
+    view: (a: A) => U,
+    update: (a: A, v: U) => A
+  ): Lens<S, NextParams<T, Adapt<A, U>>, U>
   prop<K extends keyof A>(key: K): Lens<S, NextParams<T, Prop<A, K>>, A[K]>
   path<K extends keyof any>(
     path: K
@@ -451,6 +463,10 @@ export interface Prism<S, T extends OpticParams, A> {
   compose<T2 extends OpticParams, A2>(
     optic: Lens<A, T2, A2>
   ): Prism<S, NextComposeParams<T, T2>, A2>
+  lens<U>(
+    view: (a: A) => U,
+    update: (a: A, v: U) => A
+  ): Prism<S, NextParams<T, Adapt<A, U>>, U>
   prop<K extends keyof A>(key: K): Prism<S, NextParams<T, Prop<A, K>>, A[K]>
   path<K extends keyof any>(
     path: K
@@ -575,6 +591,10 @@ export interface Traversal<S, T extends OpticParams, A> {
   compose<T2 extends OpticParams, A2>(
     optic: Lens<A, T2, A2>
   ): Traversal<S, NextComposeParams<T, T2>, A2>
+  lens<U>(
+    view: (a: A) => U,
+    update: (a: A, v: U) => A
+  ): Traversal<S, NextParams<T, Adapt<A, U>>, U>
   prop<K extends keyof A>(key: K): Traversal<S, NextParams<T, Prop<A, K>>, A[K]>
   path<K extends keyof any>(
     path: K
@@ -695,6 +715,7 @@ export interface Getter<S, A> {
 
   // Getter · Lens => Getter
   compose<T2 extends OpticParams, A2>(optic: Lens<A, T2, A2>): Getter<S, A2>
+  lens<U>(view: (a: A) => U, update: (a: A, v: U) => A): Getter<S, U>
   prop<K extends keyof A>(key: K): Getter<S, A[K]>
   path<K extends keyof any>(path: K): Getter<S, DottedPath<A, K>>
   path<K extends (keyof any)[]>(...path: K): Getter<S, TuplePath<A, K>>
@@ -770,6 +791,7 @@ export interface AffineFold<S, A> {
 
   // AffineFold · Lens => AffineFold
   compose<T2 extends OpticParams, A2>(optic: Lens<A, T2, A2>): AffineFold<S, A2>
+  lens<U>(view: (a: A) => U, update: (a: A, v: U) => A): AffineFold<S, U>
   prop<K extends keyof A>(key: K): AffineFold<S, A[K]>
   path<K extends keyof any>(path: K): AffineFold<S, DottedPath<A, K>>
   path<K extends (keyof any)[]>(...path: K): AffineFold<S, TuplePath<A, K>>
@@ -845,6 +867,7 @@ export interface Fold<S, A> {
 
   // Fold · Lens => Fold
   compose<T2 extends OpticParams, A2>(optic: Lens<A, T2, A2>): Fold<S, A2>
+  lens<U>(view: (a: A) => U, update: (a: A, v: U) => A): Fold<S, U>
   prop<K extends keyof A>(key: K): Fold<S, A[K]>
   path<K extends keyof any>(path: K): Fold<S, DottedPath<A, K>>
   path<K extends (keyof any)[]>(...path: K): Fold<S, TuplePath<A, K>>

--- a/src/internals.ts
+++ b/src/internals.ts
@@ -569,6 +569,15 @@ export class Optic {
     return new Optic(compose(this._ref, iso(there, back)))
   }
 
+  lens(view: (x: any) => any, set: (x: any, y: any) => any): Optic {
+    return new Optic(
+      compose(
+        this._ref,
+        lens(view, ([value, source]: [any, any]) => set(source, value))
+      )
+    )
+  }
+
   indexed(): Optic {
     return new Optic(compose(this._ref, indexed))
   }

--- a/tests/lens.spec.ts
+++ b/tests/lens.spec.ts
@@ -1,17 +1,17 @@
 import * as O from '../src/index'
 
 describe('lens/general', () => {
-  type Source = { foo: { bar: { baz: string | number } }; xyzzy: number }
+  type Source = { foo: { bar: { baz: string } }; xyzzy: number }
   const source: Source = { foo: { bar: { baz: 'quux' } }, xyzzy: 42 }
 
   const lens = O.optic_<Source>().lens(
     (s) => s.foo.bar.baz,
-    (s, v: number | string) => ({
+    (s, v: string) => ({
       ...s,
       foo: { ...s.foo, bar: { ...s.foo.bar, baz: v } },
     })
   )
-  type Focus = string | number
+  type Focus = string
 
   it('get', () => {
     const result: Focus = O.get(lens)(source)
@@ -29,38 +29,22 @@ describe('lens/general', () => {
     const result = O.modify(lens)((x) => `${x} UPDATED`)(source)
     expect(result).toEqual({
       foo: { bar: { baz: 'quux UPDATED' } },
-      xyzzy: 42,
-    })
-  })
-
-  type Target = { foo: { bar: { baz: number } }; xyzzy: number }
-  it('set - polymorphic', () => {
-    const result = O.set(lens)(999)(source)
-    expect(result).toEqual({
-      foo: { bar: { baz: 999 } },
-      xyzzy: 42,
-    })
-  })
-  it('modify - polymorphic', () => {
-    const result = O.modify(lens)((x) => (x as string).length)(source)
-    expect(result).toEqual({
-      foo: { bar: { baz: 4 } },
       xyzzy: 42,
     })
   })
 })
 
 describe('lens/general chained', () => {
-  type Source = { foo: { bar: { baz: number | string } }; xyzzy: number }
+  type Source = { foo: { bar: { baz: string } }; xyzzy: number }
   const source: Source = { foo: { bar: { baz: 'quux' } }, xyzzy: 42 }
 
   const lens = O.optic_<Source>()
     .prop('foo')
     .lens(
       (s) => s.bar.baz,
-      (s, v: number | string) => ({ ...s, bar: { baz: v } })
+      (s, v: string) => ({ ...s, bar: { baz: v } })
     )
-  type Focus = number | string
+  type Focus = string
 
   it('get', () => {
     const result: Focus = O.get(lens)(source)
@@ -81,26 +65,10 @@ describe('lens/general chained', () => {
       xyzzy: 42,
     })
   })
-
-  type Target = { foo: { bar: { baz: number } }; xyzzy: number }
-  it('set - polymorphic', () => {
-    const result = O.set(lens)(999)(source)
-    expect(result).toEqual({
-      foo: { bar: { baz: 999 } },
-      xyzzy: 42,
-    })
-  })
-  it('modify - polymorphic', () => {
-    const result = O.modify(lens)((x) => (x as string).length)(source)
-    expect(result).toEqual({
-      foo: { bar: { baz: 4 } },
-      xyzzy: 42,
-    })
-  })
 })
 
 describe('lens/general chained iso', () => {
-  type Source = { foo: { bar: { baz: number | string } }; xyzzy: number }
+  type Source = { foo: { bar: { baz: string } }; xyzzy: number }
   const source: { test: Source } = {
     test: { foo: { bar: { baz: 'quux' } }, xyzzy: 42 },
   }
@@ -118,7 +86,7 @@ describe('lens/general chained iso', () => {
       (s, v) => ({ bar: { ...s.bar, baz: v } })
     )
 
-  type Focus = number | string
+  type Focus = string
 
   it('get', () => {
     const result: Focus = O.get(lens)(source)
@@ -136,22 +104,6 @@ describe('lens/general chained iso', () => {
     const result = O.modify(lens)((x) => `${x} UPDATED`)(source)
     expect(result.test).toEqual({
       foo: { bar: { baz: 'quux UPDATED' } },
-      xyzzy: 42,
-    })
-  })
-
-  type Target = { foo: { bar: { baz: number } }; xyzzy: number }
-  it('set - polymorphic', () => {
-    const result = O.set(lens)(999)(source)
-    expect(result.test).toEqual({
-      foo: { bar: { baz: 999 } },
-      xyzzy: 42,
-    })
-  })
-  it('modify - polymorphic', () => {
-    const result = O.modify(lens)((x) => x.length)(source)
-    expect(result.test).toEqual({
-      foo: { bar: { baz: 4 } },
       xyzzy: 42,
     })
   })

--- a/tests/lens.spec.ts
+++ b/tests/lens.spec.ts
@@ -1,0 +1,158 @@
+import * as O from '../src/index'
+
+describe('lens/general', () => {
+  type Source = { foo: { bar: { baz: string | number } }; xyzzy: number }
+  const source: Source = { foo: { bar: { baz: 'quux' } }, xyzzy: 42 }
+
+  const lens = O.optic_<Source>().lens(
+    (s) => s.foo.bar.baz,
+    (s, v: number | string) => ({
+      ...s,
+      foo: { ...s.foo, bar: { ...s.foo.bar, baz: v } },
+    })
+  )
+  type Focus = string | number
+
+  it('get', () => {
+    const result: Focus = O.get(lens)(source)
+    expect(result).toEqual('quux')
+  })
+
+  it('set - monomorphic', () => {
+    const result = O.set(lens)('UPDATED')(source)
+    expect(result).toEqual({
+      foo: { bar: { baz: 'UPDATED' } },
+      xyzzy: 42,
+    })
+  })
+  it('modify - monomorphic', () => {
+    const result = O.modify(lens)((x) => `${x} UPDATED`)(source)
+    expect(result).toEqual({
+      foo: { bar: { baz: 'quux UPDATED' } },
+      xyzzy: 42,
+    })
+  })
+
+  type Target = { foo: { bar: { baz: number } }; xyzzy: number }
+  it('set - polymorphic', () => {
+    const result = O.set(lens)(999)(source)
+    expect(result).toEqual({
+      foo: { bar: { baz: 999 } },
+      xyzzy: 42,
+    })
+  })
+  it('modify - polymorphic', () => {
+    const result = O.modify(lens)((x) => (x as string).length)(source)
+    expect(result).toEqual({
+      foo: { bar: { baz: 4 } },
+      xyzzy: 42,
+    })
+  })
+})
+
+describe('lens/general chained', () => {
+  type Source = { foo: { bar: { baz: number | string } }; xyzzy: number }
+  const source: Source = { foo: { bar: { baz: 'quux' } }, xyzzy: 42 }
+
+  const lens = O.optic_<Source>()
+    .prop('foo')
+    .lens(
+      (s) => s.bar.baz,
+      (s, v: number | string) => ({ ...s, bar: { baz: v } })
+    )
+  type Focus = number | string
+
+  it('get', () => {
+    const result: Focus = O.get(lens)(source)
+    expect(result).toEqual('quux')
+  })
+
+  it('set - monomorphic', () => {
+    const result = O.set(lens)('UPDATED')(source)
+    expect(result).toEqual({
+      foo: { bar: { baz: 'UPDATED' } },
+      xyzzy: 42,
+    })
+  })
+  it('modify - monomorphic', () => {
+    const result = O.modify(lens)((x) => `${x} UPDATED`)(source)
+    expect(result).toEqual({
+      foo: { bar: { baz: 'quux UPDATED' } },
+      xyzzy: 42,
+    })
+  })
+
+  type Target = { foo: { bar: { baz: number } }; xyzzy: number }
+  it('set - polymorphic', () => {
+    const result = O.set(lens)(999)(source)
+    expect(result).toEqual({
+      foo: { bar: { baz: 999 } },
+      xyzzy: 42,
+    })
+  })
+  it('modify - polymorphic', () => {
+    const result = O.modify(lens)((x) => (x as string).length)(source)
+    expect(result).toEqual({
+      foo: { bar: { baz: 4 } },
+      xyzzy: 42,
+    })
+  })
+})
+
+describe('lens/general chained iso', () => {
+  type Source = { foo: { bar: { baz: number | string } }; xyzzy: number }
+  const source: { test: Source } = {
+    test: { foo: { bar: { baz: 'quux' } }, xyzzy: 42 },
+  }
+
+  const lens = O.optic_<{ test: Source }>()
+    .iso(
+      (a: { test: Source }) => a.test,
+      (a: Source) => ({
+        test: a,
+      })
+    )
+    .prop('foo')
+    .lens(
+      (s) => s.bar.baz,
+      (s, v) => ({ bar: { ...s.bar, baz: v } })
+    )
+
+  type Focus = number | string
+
+  it('get', () => {
+    const result: Focus = O.get(lens)(source)
+    expect(result).toEqual('quux')
+  })
+
+  it('set - monomorphic', () => {
+    const result = O.set(lens)('UPDATED')(source)
+    expect(result.test).toEqual({
+      foo: { bar: { baz: 'UPDATED' } },
+      xyzzy: 42,
+    })
+  })
+  it('modify - monomorphic', () => {
+    const result = O.modify(lens)((x) => `${x} UPDATED`)(source)
+    expect(result.test).toEqual({
+      foo: { bar: { baz: 'quux UPDATED' } },
+      xyzzy: 42,
+    })
+  })
+
+  type Target = { foo: { bar: { baz: number } }; xyzzy: number }
+  it('set - polymorphic', () => {
+    const result = O.set(lens)(999)(source)
+    expect(result.test).toEqual({
+      foo: { bar: { baz: 999 } },
+      xyzzy: 42,
+    })
+  })
+  it('modify - polymorphic', () => {
+    const result = O.modify(lens)((x) => x.length)(source)
+    expect(result.test).toEqual({
+      foo: { bar: { baz: 4 } },
+      xyzzy: 42,
+    })
+  })
+})


### PR DESCRIPTION
Fixes #268.

This is badly typed because I couldn't figure out `OpticParams` machinery just yet (see ignored type-errors in tests). Sending this PR as a WIP in case I received any suggestions or warnings.