### PR TITLE
Add types to exports in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,14 +17,17 @@
   "main": "./dist/cjs/index.js",
   "exports": {
     ".": {
+      "types": "./index.d.ts",
       "import": "./dist/mjs/index.js",
       "require": "./dist/cjs/index.js"
     },
     "./standalone": {
+      "types": "./standalone/index.d.ts",
       "import": "./dist/mjs/standalone/index.js",
       "require": "./dist/cjs/standalone/index.js"
     },
     "./interop": {
+      "types": "./interop.d.ts",
       "import": "./dist/mjs/interop.js",
       "require": "./dist/cjs/interop.js"
     }


### PR DESCRIPTION
This is required for moduleResolution nodenext or bundler.

Fixes #293