### PR TITLE
distributedOmit with prop tests. did not work for pick so skipping

### DIFF
--- a/src/distributedOmit.ts
+++ b/src/distributedOmit.ts
@@ -1,0 +1,3 @@
+export type DistributiveOmit<T, K extends keyof T> = T extends any
+    ? Omit<T, K>
+    : never;

--- a/src/hkt.ts
+++ b/src/hkt.ts
@@ -1,3 +1,4 @@
+import { DistributiveOmit } from './distributedOmit.js'
 import { ElemType, Eq, Prec } from './utils.js'
 
 export interface HKT {
@@ -53,7 +54,7 @@ export interface ElemUnion<A> extends HKT {
 }
 
 export interface Prop<S, K extends keyof S> extends HKT {
-  0: Omit<S, K> & { [KK in K]: this[1] }
+  0: DistributiveOmit<S, K> & { [KK in K]: this[1] }
 }
 
 export type SetTuplePath<S, K> = K extends []
@@ -87,7 +88,7 @@ export interface SetNth<S, N extends number> extends HKT {
 }
 
 export interface Plant<S, K extends keyof S> extends HKT {
-  0: Omit<S, K> & { [KK in keyof this[1]]: this[1][KK] }
+  0: DistributiveOmit<S, K> & { [KK in keyof this[1]]: this[1][KK] }
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/src/standalone/prop.ts
+++ b/src/standalone/prop.ts
@@ -1,6 +1,7 @@
 import type { Optic, TryA, TryT, A, B, S, T } from './optic.js'
 import type { NoSuchProperty } from './errors.js'
 import * as I from '../internals.js'
+import { DistributiveOmit } from '../distributedOmit.js'
 
 interface PropA<K extends string> extends A {
   0: TryA<
@@ -12,7 +13,7 @@ interface PropT<K extends string> extends T {
   0: TryT<
     this,
     K extends keyof S<this>
-      ? Omit<S<this>, K> & { [KK in K]: B<this> }
+      ? DistributiveOmit<S<this>, K> & { [KK in K]: B<this> }
       : NoSuchProperty<K, B<this>>
   >
 }

--- a/src/standalone/prop.tspec.ts
+++ b/src/standalone/prop.tspec.ts
@@ -5,6 +5,19 @@ import type { NoSuchProperty } from './errors.js'
 type Source = { foo: number; bar: { baz: string } }
 declare const s: Source
 
+type A = {
+  URI: 'A'
+  common: string
+  a: boolean
+}
+type B = {
+  URI: 'B'
+  common: string
+  b: number
+}
+
+type AOrB = A | B
+
 describe('prop', () => {
   it('error', () => {
     const result = O.get(O.prop('invalid'))(s)
@@ -14,5 +27,17 @@ describe('prop', () => {
   it('error - composed', () => {
     const result = O.get(O.compose('bar', 'baz', 'invalid'))(s)
     expectType<NoSuchProperty<'invalid', string>>()(result)()
+  })
+
+  it('preserves union', () => {
+    const a = { URI: 'A', common: 'common', a: true } as AOrB
+    const result = O.modify(O.prop('common'))((old: string) => `${old}new`)(a)
+    expectType<AOrB>()(result)
+  })
+
+  it('preserves union', () => {
+    const b: AOrB = { URI: 'B', common: 'common', b: 7 } as AOrB
+    const result = O.modify(O.prop('common'))((old: string) => `${old}new`)(b)
+    expectType<AOrB>()(result)
   })
 })


### PR DESCRIPTION
u may like to organize this differently and i didnt look into why distributedOmit didnt work for pick, but as i dont use that and really want to use your library but need it to preserve unions for fork, i built a fix and a type test for it

i looked at effect ts and monocle and had different issues with each, yours seems the most ergonomic and i like the standalone api since i can compose things together independently of the parent types allowing me to avoid repetitive optics

but i need it to work with my unions or i cant use it. about to try incorporating this fork into my app and see how that goes and if i run into any other challenges

really hoping to find a reliable and simple optics capability for typescript

thanks for all the work u put into this